### PR TITLE
fix(auth): read exists field from payload instead of message string

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -25,7 +25,7 @@ export async function postCheckPhoneNumber({ phoneNumber }) {
   const response = await api.post(`${BASE_URL}/phone-number-has-user`, {
     phoneNumber,
   });
-  return response.message === "User found";
+  return response?.exists === true;
 }
 
 export function postCreateAccount(user) {


### PR DESCRIPTION
The Axios interceptor extracts res.data.payload from all responses. postCheckPhoneNumber was reading response.message which was undefined after the interceptor unwrapped the payload, causing a silent TypeError that made the phone submission screen reset without feedback.