### PR TITLE
fix(auth): auto-login from email token no longer requires phone+code

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import styles from "./App.module.css";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import ScheduleAppointment from "./routes/ScheduleAppointment";
 import SelectAppointment from "./routes/SelectAppointment";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getAllLocations } from "./api/locations";
 import InfoCheck from "./components/InfoCheck";
 import AppointmentList from "./routes/AppointmentList";
@@ -10,7 +10,9 @@ import { useTokenStore } from "./store";
 import { Settings } from "luxon";
 
 export default function App() {
-	const { token, setToken } = useTokenStore((state) => state);
+	const { token: storedToken, setToken } = useTokenStore((state) => state);
+	const urlToken = useMemo(() => new URLSearchParams(window.location.search).get("token"), []);
+	const token = urlToken ?? storedToken;
 	const [name, setName] = useState("");
 	const [dependents, setDependents] = useState(null);
 	const [locations, setLocations] = useState(null);

--- a/src/components/InfoCheck.js
+++ b/src/components/InfoCheck.js
@@ -26,20 +26,20 @@ export default function InfoCheck({
 
   useEffect(() => {
     async function fetchData() {
-      // eslint-disable-next-line eqeqeq
-      if (token != "" && name == "" && dependents == null) {
-        const {
-          user: { name, dependents, restrictionLevel },
-        } = await getMe();
-        setLoading(false);
-        if (name) {
-          setName(name);
+      if (token && name === "" && dependents === null) {
+        try {
+          const {
+            user: { name: fetchedName, dependents: fetchedDependents, restrictionLevel },
+          } = await getMe();
+          setLoading(false);
+          if (fetchedName) setName(fetchedName);
+          if (fetchedDependents) setDependents(fetchedDependents);
+          setRestrictionlevel(restrictionLevel);
+          setStep("continue");
+        } catch (_err) {
+          setStep("requestPhone");
         }
-        if (dependents) {
-          setDependents(dependents);
-        }
-        setRestrictionlevel(restrictionLevel)
-      } else {
+      } else if (token) {
         setStep("continue");
       }
     }


### PR DESCRIPTION
- Extract URL token synchronously via useMemo in App.js so InfoCheck receives the correct token on first render, eliminating the race condition that caused the phone screen to always appear
- Fix loose null check (null != "" is true) that triggered a spurious unauthenticated getMe() call on every initial render
- Add try/catch around getMe() so expired/invalid tokens gracefully fall back to the phone+code flow
- Call setStep("continue") explicitly after successful getMe() instead of relying on a fragile side-effect chain through setName