### PR TITLE
fix(auth): initialize token store synchronously from URL and localSto…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import styles from "./App.module.css";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import ScheduleAppointment from "./routes/ScheduleAppointment";
 import SelectAppointment from "./routes/SelectAppointment";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { getAllLocations } from "./api/locations";
 import InfoCheck from "./components/InfoCheck";
 import AppointmentList from "./routes/AppointmentList";
@@ -10,9 +10,7 @@ import { useTokenStore } from "./store";
 import { Settings } from "luxon";
 
 export default function App() {
-	const { token: storedToken, setToken } = useTokenStore((state) => state);
-	const urlToken = useMemo(() => new URLSearchParams(window.location.search).get("token"), []);
-	const token = urlToken ?? storedToken;
+	const { token, setToken } = useTokenStore((state) => state);
 	const [name, setName] = useState("");
 	const [dependents, setDependents] = useState(null);
 	const [locations, setLocations] = useState(null);

--- a/src/store.js
+++ b/src/store.js
@@ -1,8 +1,18 @@
 import { createStore } from "zustand/vanilla";
 import { useStore } from "zustand";
 
+function getInitialToken() {
+	const urlToken = new URLSearchParams(window.location.search).get("token");
+	if (urlToken) return urlToken;
+	try {
+		return localStorage.getItem("token");
+	} catch (_err) {
+		return null;
+	}
+}
+
 export const tokenStore = createStore((set) => ({
-	token: null,
+	token: getInitialToken(),
 	setToken: (token) => {
 		try {
 			localStorage.setItem("token", token);


### PR DESCRIPTION
…rage

The previous fix passed the URL token to InfoCheck's prop but the axios interceptor reads from the Zustand store directly, which still had token: null on first render — causing 401s on every API call.

Move token initialization into the store itself via getInitialToken(), which reads the URL ?token= param first and falls back to localStorage. This ensures the store (and the axios interceptor) have the correct token before any component renders or API call is made.